### PR TITLE
Update setup.sh script as set-script command is deprecated in npm

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-npm set-script prepare "npx husky install"
+npm pkg set scripts.prepare="npx husky install"
 npm run prepare
 npx husky set .husky/pre-commit "npx lint-staged"
 


### PR DESCRIPTION
Ifølge dette issuet [(https://github.com/typicode/husky/issues/1150#issuecomment-1428449543 )] er `npm set-script` utdatert, og vår setup.sh vil derfor ikke fungere. Oppdaterer scriptet med forslaget nevnt i issuet